### PR TITLE
example: Fix Qt Creator project file include path to qserializer.pri

### DIFF
--- a/example/QSDeserialize/QSDeserialize.pro
+++ b/example/QSDeserialize/QSDeserialize.pro
@@ -14,7 +14,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-include(../../src/QSerializer.pri)
+include(../../qserializer.pri)
 include(../base.pri)
 
 SOURCES += \

--- a/example/QSSerialize/QSSerialize.pro
+++ b/example/QSSerialize/QSSerialize.pro
@@ -14,7 +14,7 @@ CONFIG -= app_bundle
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-include(../../src/QSerializer.pri)
+include(../../qserializer.pri)
 include(../base.pri)
 
 SOURCES += \


### PR DESCRIPTION
Currently the examples are broken and are unable to be compiled because the include path is incorrect