### PR TITLE
Fix compiler warning about virtual destructor -Wdelete-non-abstract-non-virtual-dtor

### DIFF
--- a/src/qserializer.h
+++ b/src/qserializer.h
@@ -64,6 +64,8 @@ public:
     QSerializer(){
     }
 
+    virtual ~QSerializer() {}
+
     ///\brief Convert QJsonValue in QJsonDocument as QByteArray
     static QByteArray toByteArray(const QJsonValue & value){
         return QJsonDocument(value.toObject()).toJson();


### PR DESCRIPTION
Environment:
```
jerry@Jerrys-iMac QSSerialize % clang++ --version
Apple clang version 13.0.0 (clang-1300.0.29.3)
Target: x86_64-apple-darwin21.1.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

```
jerry@Jerrys-iMac QSSerialize % qmake --version
QMake version 3.1
Using Qt version 6.2.1 in /usr/local/lib
```

Error (one of many)
```
In file included from moc_classes.cpp:9:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/memory:670:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/typeinfo:61:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/exception:81:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/base.h:118:5: warning: destructor called on non-final 'Parent' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    __loc->~_Tp();
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/memory:2294:16: note: in instantiation of function template specialization 'std::destroy_at<Parent>' requested here
        _VSTD::destroy_at(_VSTD::addressof(*__first));
               ^
/usr/local/lib/QtCore.framework/Headers/qarraydataops.h:392:14: note: in instantiation of function template specialization 'std::destroy<Parent *>' requested here
        std::destroy(this->begin(), this->end());
             ^
/usr/local/lib/QtCore.framework/Headers/qarraydatapointer.h:130:22: note: in instantiation of member function 'QtPrivate::QGenericArrayOps<Parent>::destroyAll' requested here
            (*this)->destroyAll();
                     ^
/usr/local/lib/QtCore.framework/Headers/qlist.h:248:5: note: in instantiation of member function 'QArrayDataPointer<Parent>::~QArrayDataPointer' requested here
    QList() = default;
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/base.h:118:13: note: qualify call to silence this warning
    __loc->~_Tp();
            ^
```